### PR TITLE
Fix link to cxx-kde-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I ~~break~~ make things !
 ### Cool projects that I worked on:
 
 - [Pixelorama](https://github.com/Orama-Interactive/Pixelorama) - Pixel Art program made in Godot Engine
-- [cxx-kde-frameworks](https://invent.org/libraries/cxx-kde-frameworks) - Rust Bridge for KDE Frameworks
+- [cxx-kde-frameworks](https://invent.kde.org/libraries/cxx-kde-frameworks) - Rust Bridge for KDE Frameworks
 
 #### Minecraft Mods
 - [EnderIO](https://github.com/Team-EnderIO/EnderIO) - Necromancy Tech mod


### PR DESCRIPTION
This is supposed to be to invent.kde.org, not invent.org :)